### PR TITLE
Cache bust tf downloads

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -21,7 +21,8 @@ jobs:
           key: ${{ github.ref }}
           path: .cache
       - run: |
-          pip install mkdocs mkdocs-material
+          # mkdocs >=1.4 required for `hooks:` config support (see https://www.mkdocs.org/about/release-notes/#version-14-2022-09-27)
+          pip install 'mkdocs>=1.4' mkdocs-material
           mkdocs --version
           cd ./docs
           mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,12 @@
 # mkdocs
-docs/site/*
+docs/site/
+site/
+
+# python
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+
+# macOS
+.DS_Store

--- a/docs/docs/assets/sec545-l01.tf
+++ b/docs/docs/assets/sec545-l01.tf
@@ -469,7 +469,7 @@ resource "aws_instance" "web" {
   subnet_id              = aws_subnet.subnet1.id
   vpc_security_group_ids = [aws_security_group.sec545vm.id]
   root_block_device {
-    volume_size = 150
+    volume_size = 100
   }
 
   associate_public_ip_address = true

--- a/docs/docs/assets/sec545-l01.tf
+++ b/docs/docs/assets/sec545-l01.tf
@@ -230,7 +230,7 @@ resource "aws_security_group" "sec545vm" {
     to_port     = 54000
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
-#    cidr_blocks = [local.allowed_cidr]
+    #    cidr_blocks = [local.allowed_cidr]
   }
 
   egress {
@@ -469,7 +469,7 @@ resource "aws_instance" "web" {
   subnet_id              = aws_subnet.subnet1.id
   vpc_security_group_ids = [aws_security_group.sec545vm.id]
   root_block_device {
-    volume_size = 100
+    volume_size = 150
   }
 
   associate_public_ip_address = true

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,0 +1,25 @@
+import os
+import re
+import subprocess
+
+
+def _version() -> str:
+    sha = os.environ.get("GITHUB_SHA")
+    if sha:
+        return sha[:12]
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except Exception:
+        return "dev"
+
+
+VERSION = _version()
+_TF_LINK = re.compile(r"(\]\([^)]*?\.tf)(\))")
+
+
+def on_page_markdown(markdown, **kwargs):
+    return _TF_LINK.sub(rf"\1?v={VERSION}\2", markdown)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -3,6 +3,9 @@ copyright: "©2025 Eric Johnson, Ben Allen, and Frank Kim."
 site_description: "SANS Cloud Security Flight Simulator setup instructions and bootstrap template."
 site_author: "Eric Johnson, Ben Allen, and Frank Kim"
 
+hooks:
+  - hooks.py
+
 theme:
   name: "material"
   palette:


### PR DESCRIPTION
This changes the download links for the `.tf` files to have unique query params so it cache busts; I saw that if you downloaded a .tf file before, then update it, then go back and download again, it was the old data. So, in 545 we fixed a bug (https://github.com/sans-cloud-sec540/simulator/commit/69b80264d2e4889c408c359990ed2015b93a31bf) but 2 weeks later when I re-downloaded the `.tf` I got the old, buggy version still

I don't have a great way to test this e2e, but local testing looks good